### PR TITLE
Add BERT model

### DIFF
--- a/bert_env.yml
+++ b/bert_env.yml
@@ -1,0 +1,14 @@
+name: bert_env
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.10
+  - tensorflow=2.10
+  - pandas
+  - numpy
+  - scikit-learn
+  - pip
+  - pip:
+      - tensorflow-hub
+      - tensorflow-text==2.10.0

--- a/bert_model.ipynb
+++ b/bert_model.ipynb
@@ -1,0 +1,399 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "4abaa33f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports\n",
+    "import tensorflow as tf\n",
+    "import tensorflow_hub as hub\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import tensorflow_text as text\n",
+    "from keras.metrics import Recall\n",
+    "from tensorflow import keras\n",
+    "from sklearn.metrics import precision_score, recall_score, f1_score\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "import csv\n",
+    "from tensorflow.python.keras.metrics import Precision, Recall\n",
+    "from sklearn.metrics import classification_report"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3938392",
+   "metadata": {},
+   "source": [
+    "# Data processing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "a62bdbd9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "csv.field_size_limit(100000000)\n",
+    "\n",
+    "#filepath = \"dataset/news_cleaned_2018_02_13.csv\"\n",
+    "#selected_columns = [\"domain\", \"title\", \"authors\", \"type\", \"content\", \"url\"]\n",
+    "\n",
+    "#chunks = []\n",
+    "#for chunk in pd.read_csv(filepath, usecols=selected_columns, chunksize=100000, on_bad_lines='warn', engine='python'):\n",
+    "#    sample = chunk.sample(frac=0.1, random_state=42)\n",
+    "#    chunks.append(sample)\n",
+    "\n",
+    "#df = pd.concat(chunks, ignore_index=True)\n",
+    "#train_dataframe, temp_dataframe = train_test_split(df, test_size=0.2, random_state=42) # 80% for training and temp for validation and testing\n",
+    "#validation_dataframe, test_dataframe = train_test_split(temp_dataframe, test_size=0.5, random_state=42) # splitting the temp data into 10% for validation and 10% for testing\n",
+    "\n",
+    "#train_dataframe.to_csv(\"dataset/train_data_final.csv\", chunksize=100000)\n",
+    "#validation_dataframe.to_csv(\"dataset/validation_data_final.csv\", chunksize=100000)\n",
+    "#test_dataframe.to_csv(\"dataset/test_data_final.csv\", chunksize=100000)\n",
+    "\n",
+    "# get dataset from previously loaded\n",
+    "train_file_path = \"dataset/train_data_final.csv\"\n",
+    "train_data_chunks = []\n",
+    "for chunk in pd.read_csv(train_file_path, chunksize=100000, on_bad_lines='warn', engine='python'):\n",
+    "    chunk = chunk.dropna(subset=['content', 'type'])\n",
+    "    # adding label column which tells whether the article is reliable (=1) or not (=0)\n",
+    "    chunk[\"label\"] = chunk[\"type\"].apply(lambda x: 1 if str(x).strip().lower() == \"reliable\" else 0)\n",
+    "    train_data_chunks.append(chunk)\n",
+    "\n",
+    "train_data = pd.concat(train_data_chunks, ignore_index=True)\n",
+    "\n",
+    "test_file_path = \"dataset/test_data_final.csv\"\n",
+    "test_data_chunks = []\n",
+    "for chunk in pd.read_csv(test_file_path, chunksize=100000, on_bad_lines='warn', engine='python'):\n",
+    "    chunk = chunk.dropna(subset=['content', 'type'])\n",
+    "    # adding label column which tells whether the article is reliable (=1) or not (=0)\n",
+    "    chunk[\"label\"] = chunk[\"type\"].apply(lambda x: 1 if str(x).strip().lower() == \"reliable\" else 0)\n",
+    "    test_data_chunks.append(chunk)\n",
+    "\n",
+    "test_data = pd.concat(test_data_chunks, ignore_index=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "f85c86c8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sample label distribution:\n",
+      "label\n",
+      "0    497052\n",
+      "1    152883\n",
+      "Name: count, dtype: int64\n",
+      "label\n",
+      "0    62258\n",
+      "1    19120\n",
+      "Name: count, dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Sample label distribution:\")\n",
+    "print(train_data['label'].value_counts())\n",
+    "print(test_data['label'].value_counts())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f69bb6dc",
+   "metadata": {},
+   "source": [
+    "# Bert model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "e9b46571",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert to TensorFlow datasets using raw text\n",
+    "train_dataset = tf.data.Dataset.from_tensor_slices((train_data['content'].tolist(), train_data['label'].tolist()))\n",
+    "test_dataset = tf.data.Dataset.from_tensor_slices((test_data['content'].tolist(), test_data['label'].tolist()))\n",
+    "\n",
+    "# Batch datasets\n",
+    "train_dataset = train_dataset.batch(64).prefetch(tf.data.AUTOTUNE)\n",
+    "test_dataset = test_dataset.batch(64).prefetch(tf.data.AUTOTUNE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "21fdcda0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/5\n",
+      "10156/10156 [==============================] - 13980s 1s/step - loss: 0.1584 - accuracy: 0.9388 - precision_3: 0.8734 - recall_3: 0.7940 - val_loss: 0.1267 - val_accuracy: 0.9524 - val_precision_3: 0.8982 - val_recall_3: 0.8379\n",
+      "Epoch 2/5\n",
+      "10156/10156 [==============================] - 13777s 1s/step - loss: 0.1128 - accuracy: 0.9577 - precision_3: 0.9075 - recall_3: 0.8525 - val_loss: 0.1320 - val_accuracy: 0.9511 - val_precision_3: 0.9150 - val_recall_3: 0.8613\n",
+      "Epoch 3/5\n",
+      "10156/10156 [==============================] - 14255s 1s/step - loss: 0.0914 - accuracy: 0.9662 - precision_3: 0.9208 - recall_3: 0.8687 - val_loss: 0.1321 - val_accuracy: 0.9543 - val_precision_3: 0.9252 - val_recall_3: 0.8753\n",
+      "Epoch 4/5\n",
+      "10156/10156 [==============================] - 13440s 1s/step - loss: 0.0762 - accuracy: 0.9721 - precision_3: 0.9290 - recall_3: 0.8813 - val_loss: 0.1324 - val_accuracy: 0.9561 - val_precision_3: 0.9321 - val_recall_3: 0.8866\n",
+      "Epoch 5/5\n",
+      "10156/10156 [==============================] - 12792s 1s/step - loss: 0.0643 - accuracy: 0.9766 - precision_3: 0.9348 - recall_3: 0.8915 - val_loss: 0.1469 - val_accuracy: 0.9546 - val_precision_3: 0.9371 - val_recall_3: 0.8959\n"
+     ]
+    }
+   ],
+   "source": [
+    "bert_preprocess = hub.KerasLayer('https://tfhub.dev/tensorflow/bert_en_uncased_preprocess/3')\n",
+    "bert_model = hub.KerasLayer('https://tfhub.dev/tensorflow/small_bert/bert_en_uncased_L-2_H-128_A-2/2', trainable=True)\n",
+    "\n",
+    "text_input = keras.layers.Input(shape=(), dtype=tf.string, name='text')\n",
+    "preprocessed_text = bert_preprocess(text_input)\n",
+    "bert_output = bert_model(preprocessed_text)['pooled_output']\n",
+    "dense = tf.keras.layers.Dense(64, activation='relu')(bert_output)\n",
+    "output = tf.keras.layers.Dense(1, activation='sigmoid')(dense)\n",
+    "\n",
+    "model = keras.Model(inputs=[text_input], outputs=[output])\n",
+    "\n",
+    "model.compile(optimizer='adam', loss=tf.keras.losses.BinaryCrossentropy(), metrics=['accuracy', Precision(), Recall()])\n",
+    "history = model.fit(train_dataset, epochs=5, validation_data=test_dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbd4c556",
+   "metadata": {},
+   "source": [
+    "## Evaluate the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "c7a989e9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1272/1272 [==============================] - 879s 691ms/step - loss: 0.1469 - accuracy: 0.9546 - precision_3: 0.9371 - recall_3: 0.8953\n",
+      "Results: \n",
+      " Test accuracy: 0.9545700550079346 \n",
+      " Test loss: 0.14685742557048798 \n",
+      " Test precision: 0.9371037483215332 \n",
+      " Test recall: 0.8952885270118713 \n",
+      " Test F1_Score: 0.9157190256539762\n",
+      "2544/2544 [==============================] - 1008s 396ms/step\n",
+      "              precision    recall  f1-score   support\n",
+      "\n",
+      "           0       0.96      0.98      0.97     62258\n",
+      "           1       0.94      0.87      0.90     19120\n",
+      "\n",
+      "    accuracy                           0.95     81378\n",
+      "   macro avg       0.95      0.92      0.94     81378\n",
+      "weighted avg       0.95      0.95      0.95     81378\n",
+      "\n",
+      "Test Precision: 0.9353582114830915\n",
+      "Test Recall: 0.8665271966527197\n",
+      "Test F1 Score: 0.8996280509325876\n"
+     ]
+    }
+   ],
+   "source": [
+    "loss, accuracy, precision, recall = model.evaluate(test_dataset)\n",
+    "\n",
+    "print(f\"Results: \\n Test accuracy: {accuracy} \\n Test loss: {loss} \\n Test precision: {precision} \\n Test recall: {recall}\")\n",
+    "\n",
+    "# Predictions and final metrics\n",
+    "true_labels = test_data['label'].values\n",
+    "# create dataset for processing and to avoid memory error\n",
+    "test_content = tf.data.Dataset.from_tensor_slices(test_data['content'].values)\n",
+    "test_content = test_content.batch(32).prefetch(tf.data.AUTOTUNE)\n",
+    "predictions = model.predict(test_content)\n",
+    "predicted_labels = (predictions > 0.5).astype(int).flatten()\n",
+    "\n",
+    "# Calculate precision, recall, and F1 score\n",
+    "\n",
+    "print(classification_report(true_labels, predicted_labels))\n",
+    "\n",
+    "test_precision = precision_score(true_labels, predicted_labels)\n",
+    "test_recall = recall_score(true_labels, predicted_labels)\n",
+    "test_f1 = f1_score(true_labels, predicted_labels)\n",
+    "\n",
+    "print(f\"Test Precision: {test_precision}\")\n",
+    "print(f\"Test Recall: {test_recall}\")\n",
+    "print(f\"Test F1 Score: {test_f1}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa1d10e9",
+   "metadata": {},
+   "source": [
+    "# Validate with LIAR"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b4d3002",
+   "metadata": {},
+   "source": [
+    "## Preprocess LIAR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86da5560",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Label distribution in liar test set: binary_label\n",
+      "0    64.561957\n",
+      "1    35.438043\n",
+      "Name: proportion, dtype: float64\n",
+      "Label distribution in liar validation set: binary_label\n",
+      "0    67.28972\n",
+      "1    32.71028\n",
+      "Name: proportion, dtype: float64\n"
+     ]
+    }
+   ],
+   "source": [
+    "# already converted to csv\n",
+    "liar_test_data_path = \"dataset/liar/test.csv\"\n",
+    "liar_test_chunks = []\n",
+    "for chunk in pd.read_csv(liar_test_data_path, chunksize=10000, on_bad_lines='warn', engine='python'):\n",
+    "    # labels in liar = true, false, half-true, pants-fire, barely-true, mostly-true\n",
+    "    # only true and mostly-true are true others are false\n",
+    "    # converting labels to binary 1=true, 0=false\n",
+    "    chunk[\"binary_label\"] = chunk[\"label\"].apply(lambda x: 1 if str(x).strip().lower() in [\"true\", \"mostly-true\"] else 0)\n",
+    "    liar_test_chunks.append(chunk)\n",
+    "\n",
+    "liar_test_data = pd.concat(liar_test_chunks, ignore_index=True)\n",
+    "\n",
+    "liar_valid_data_path = \"dataset/liar/valid.csv\"\n",
+    "liar_valid_chunks = []\n",
+    "for chunk in pd.read_csv(liar_valid_data_path, chunksize=10000, on_bad_lines='warn', engine='python'):\n",
+    "    # labels in liar = true, false, half-true, pants-fire, barely-true, mostly-true\n",
+    "    # only true and mostly-true are true others are false\n",
+    "    # converting labels to binary 1=true, 0=false\n",
+    "    chunk[\"binary_label\"] = chunk[\"label\"].apply(lambda x: 1 if str(x).strip().lower() in [\"true\", \"mostly-true\"] else 0)\n",
+    "    liar_valid_chunks.append(chunk)\n",
+    "\n",
+    "liar_valid_data = pd.concat(liar_valid_chunks, ignore_index=True)\n",
+    "\n",
+    "label_distribution_test = liar_test_data[\"binary_label\"].value_counts(normalize=True) * 100 # counting the distribution\n",
+    "label_distribution_valid = liar_valid_data[\"binary_label\"].value_counts(normalize=True) * 100 # counting the distribution\n",
+    "print(f\"Label distribution in liar test set: {label_distribution_test}\")\n",
+    "print(f\"Label distribution in liar validation set: {label_distribution_valid}\")\n",
+    "\n",
+    "# Convert to TensorFlow datasets using raw text\n",
+    "liar_valid_dataset = tf.data.Dataset.from_tensor_slices((liar_valid_data['statement'].tolist(), liar_valid_data['binary_label'].tolist()))\n",
+    "# Batch dataset\n",
+    "liar_valid_dataset = liar_valid_dataset.batch(64).prefetch(tf.data.AUTOTUNE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e561881c",
+   "metadata": {},
+   "source": [
+    "## Evaluate with LIAR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "3353bcb4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21/21 [==============================] - 10s 468ms/step - loss: 1.7774 - accuracy: 0.6706 - precision_3: 0.9371 - recall_3: 0.8943\n",
+      "Results: \n",
+      " Test accuracy: 0.6705607771873474 \n",
+      " Test loss: 1.7774035930633545 \n",
+      " Test precision: 0.9370768666267395 \n",
+      " Test recall: 0.8943120837211609\n",
+      "41/41 [==============================] - 15s 355ms/step\n",
+      "              precision    recall  f1-score   support\n",
+      "\n",
+      "           0       0.67      0.99      0.80       864\n",
+      "           1       0.43      0.02      0.04       420\n",
+      "\n",
+      "    accuracy                           0.67      1284\n",
+      "   macro avg       0.55      0.50      0.42      1284\n",
+      "weighted avg       0.59      0.67      0.55      1284\n",
+      "\n",
+      "Test Precision: 0.42857142857142855\n",
+      "Test Recall: 0.02142857142857143\n",
+      "Test F1 Score: 0.04081632653061224\n"
+     ]
+    }
+   ],
+   "source": [
+    "valid_loss, valid_accuracy, valid_precision, valid_recall = model.evaluate(liar_valid_dataset)\n",
+    "\n",
+    "print(f\"Results: \\n Test accuracy: {valid_accuracy} \\n Test loss: {valid_loss} \\n Test precision: {valid_precision} \\n Test recall: {valid_recall}\")\n",
+    "\n",
+    "\n",
+    "# Predictions and final metrics\n",
+    "true_labels = liar_valid_data['binary_label'].values\n",
+    "# create dataset for processing and to avoid memory error\n",
+    "liar_valid_statement = tf.data.Dataset.from_tensor_slices(liar_valid_data['statement'].values)\n",
+    "liar_valid_statement = liar_valid_statement.batch(32).prefetch(tf.data.AUTOTUNE)\n",
+    "predictions = model.predict(liar_valid_statement)\n",
+    "predicted_labels = (predictions > 0.5).astype(int).flatten()\n",
+    "\n",
+    "# Calculate precision, recall, and F1 score\n",
+    "\n",
+    "print(classification_report(true_labels, predicted_labels))\n",
+    "\n",
+    "valid_precision = precision_score(true_labels, predicted_labels)\n",
+    "valid_recall = recall_score(true_labels, predicted_labels)\n",
+    "valid_f1 = f1_score(true_labels, predicted_labels)\n",
+    "\n",
+    "print(f\"Test Precision: {valid_precision}\")\n",
+    "print(f\"Test Recall: {valid_recall}\")\n",
+    "print(f\"Test F1 Score: {valid_f1}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "bert_env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
* Add BERT model notebook with results, including LIAR validation. BERT uses small bert and bert preprocessing
* Model run uses already created dataset split to save time, it is the same dataset used in LSTM model
* Include bert environment to ensure repeatability